### PR TITLE
[feat] 리뷰 생성 API 및 테스트 코드 추가

### DIFF
--- a/src/main/java/com/example/studyspot/review/controller/ReviewController.java
+++ b/src/main/java/com/example/studyspot/review/controller/ReviewController.java
@@ -1,0 +1,33 @@
+package com.example.studyspot.review.controller;
+
+import com.example.studyspot.review.dto.CreateReviewCommand;
+import com.example.studyspot.review.dto.CreateReviewRequest;
+import com.example.studyspot.review.dto.ReviewResponse;
+import com.example.studyspot.review.service.ReviewService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reviews")
+public class ReviewController {
+    @Autowired
+    private ReviewService reviewService;
+
+    //Create
+    @PostMapping("/{cafeId}")
+    public ResponseEntity<ReviewResponse> create(
+            @PathVariable Long cafeId,
+            @Valid @RequestBody CreateReviewRequest body
+    ){
+        ReviewResponse created = reviewService.create(
+                new CreateReviewCommand(cafeId, body.starRating(), body.content()));
+
+        return ResponseEntity.status(201).body(created);
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/studyspot/review/domain/model/Review.java
+++ b/src/main/java/com/example/studyspot/review/domain/model/Review.java
@@ -1,0 +1,27 @@
+package com.example.studyspot.review.domain.model;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class Review {
+    @Id
+    private Long id;
+
+    private Long uuserId;
+    private Long cafeId;
+    private Double starRating;
+    private LocalDateTime createdAt; //타입 timeStamp
+    private String content;
+
+}

--- a/src/main/java/com/example/studyspot/review/dto/CreateReviewCommand.java
+++ b/src/main/java/com/example/studyspot/review/dto/CreateReviewCommand.java
@@ -1,0 +1,13 @@
+package com.example.studyspot.review.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record CreateReviewCommand (
+        long cafeId,
+        double starRating,
+        String content
+){
+}

--- a/src/main/java/com/example/studyspot/review/dto/CreateReviewRequest.java
+++ b/src/main/java/com/example/studyspot/review/dto/CreateReviewRequest.java
@@ -1,0 +1,15 @@
+package com.example.studyspot.review.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record CreateReviewRequest(
+        @Positive
+        @DecimalMin("0.0")
+        @DecimalMax("5.0")
+        double starRating,
+        @NotBlank String content
+) {
+}

--- a/src/main/java/com/example/studyspot/review/dto/ReviewResponse.java
+++ b/src/main/java/com/example/studyspot/review/dto/ReviewResponse.java
@@ -1,0 +1,6 @@
+package com.example.studyspot.review.dto;
+
+public record ReviewResponse (
+        Long id
+) {
+}

--- a/src/main/java/com/example/studyspot/review/repository/MemoryReviewRepository.java
+++ b/src/main/java/com/example/studyspot/review/repository/MemoryReviewRepository.java
@@ -1,0 +1,38 @@
+package com.example.studyspot.review.repository;
+
+import com.example.studyspot.review.domain.model.Review;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class MemoryReviewRepository implements ReviewRepository{
+
+    private static Map<Long,Review> store = new HashMap<>();
+    private static long uniqueId = 0; //Id 발급기
+
+    @Override
+    public Review save(Review review) {
+        long id = uniqueId++;
+        review.setId(id);
+        store.put(review.getId(),review);
+        return review;
+    }
+
+    @Override
+    public Review findById(Long reviewId) {
+        return store.get(reviewId);
+    }
+
+    @Override
+    public List<Review> findAllByCafeId(Long cafeId) {
+        return List.of();
+    }
+
+    @Override
+    public void clear(){
+        store.clear();
+    }
+}

--- a/src/main/java/com/example/studyspot/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/studyspot/review/repository/ReviewRepository.java
@@ -1,0 +1,15 @@
+package com.example.studyspot.review.repository;
+
+import com.example.studyspot.review.domain.model.Review;
+
+import java.util.List;
+
+public interface ReviewRepository {
+    Review save(Review review);
+
+    Review findById(Long reviewId);
+
+    List<Review> findAllByCafeId(Long cafeId);
+
+    void clear();
+}

--- a/src/main/java/com/example/studyspot/review/service/ReviewService.java
+++ b/src/main/java/com/example/studyspot/review/service/ReviewService.java
@@ -1,0 +1,16 @@
+package com.example.studyspot.review.service;
+
+import com.example.studyspot.review.domain.model.Review;
+import com.example.studyspot.review.dto.CreateReviewCommand;
+import com.example.studyspot.review.dto.ReviewResponse;
+
+import java.util.List;
+
+public interface ReviewService {
+
+    //리뷰 등록
+    ReviewResponse create(CreateReviewCommand command);
+
+    //리뷰 조회
+    List<Review> findAllByCafeId(Long cafeId);
+}

--- a/src/main/java/com/example/studyspot/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/studyspot/review/service/ReviewServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.studyspot.review.service;
+
+import com.example.studyspot.review.domain.model.Review;
+import com.example.studyspot.review.dto.CreateReviewCommand;
+import com.example.studyspot.review.dto.ReviewResponse;
+import com.example.studyspot.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService{
+
+    private final ReviewRepository reviewRepository;
+
+
+    @Override
+    public ReviewResponse create(CreateReviewCommand command) {
+        //카페 존재 여부 검증 - 추후
+
+        // Review Entity 생성
+        Review review = new Review(
+                null, // 추후 DB 사용시 변환하기
+                null, // 추후 인증 로직 구현시 사용 userId
+                command.cafeId(),
+                command.starRating(),
+                LocalDateTime.now(),
+                command.content()
+        );
+
+        //db 저장
+        Review stored = reviewRepository.save(review);
+
+        //응답 dto 반환
+        return new ReviewResponse(stored.getId());
+
+    }
+
+    @Override
+    public List<Review> findAllByCafeId(Long cafeId) {
+        return List.of();
+    }
+
+
+}

--- a/src/test/java/com/example/studyspot/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/studyspot/review/controller/ReviewControllerTest.java
@@ -1,0 +1,51 @@
+package com.example.studyspot.review.controller;
+
+import com.example.studyspot.review.dto.CreateReviewCommand;
+import com.example.studyspot.review.dto.CreateReviewRequest;
+import com.example.studyspot.review.dto.ReviewResponse;
+import com.example.studyspot.review.service.ReviewService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReviewController.class)
+class ReviewControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ReviewService reviewService;
+
+    @Test
+    void 리뷰_생성_검증() throws Exception{
+        //Service 부분 Mock 처리
+        ReviewResponse mockResponse = new ReviewResponse(0L);
+        when(reviewService.create(any(CreateReviewCommand.class))).thenReturn(mockResponse);
+
+        // 실제 request값 정해주기
+        CreateReviewRequest body = new CreateReviewRequest(5.0, "커피 좋아요");
+
+        String json = objectMapper.writeValueAsString(body);
+
+        mockMvc.perform(
+                post("/reviews/{cafeId}",1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json)
+        ).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(0L));
+
+    }
+}

--- a/src/test/java/com/example/studyspot/review/repository/MemoryReviewRepositoryTest.java
+++ b/src/test/java/com/example/studyspot/review/repository/MemoryReviewRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.example.studyspot.review.repository;
+
+import com.example.studyspot.review.domain.model.Review;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemoryReviewRepositoryTest {
+
+    ReviewRepository reviewRepository;
+
+    @BeforeEach
+    void setUp(){
+        reviewRepository = new MemoryReviewRepository();
+    }
+
+    @AfterEach
+    void clear(){
+        reviewRepository.clear();
+    }
+
+    @Test
+    @DisplayName("리뷰가 잘 저장되었는지 확인하는 테스트")
+    void 리뷰_저장_테스트(){
+        Review review = new Review(
+                null, // 추후 DB 사용시 변환하기
+                null, // 추후 인증 로직 구현시 사용 userId
+                2L,
+                4.5,
+                LocalDateTime.now(),
+                "강아지랑 오기 좋아요."
+        );
+
+        Review stored = reviewRepository.save(review);
+        Review newReview = reviewRepository.findById(stored.getId());
+        System.out.println(newReview);
+        assertThat(review).isSameAs(newReview);
+    }
+
+    @Test
+    @DisplayName("memory에서 저장할때, memory 내부에서 id 값이 중복되지 않도록 0에서 부터 증가하는 형태로 부여하는데, 잘 반영되는지 확인")
+    void 리뷰_식별_아이디_확인(){
+        Review review = new Review(
+                null, // 추후 DB 사용시 변환하기
+                null, // 추후 인증 로직 구현시 사용 userId
+                2L,
+                4.5,
+                LocalDateTime.now(),
+                "고양이랑 오기 좋아요."
+        );
+        Review review2 = new Review(
+                null, // 추후 DB 사용시 변환하기
+                null, // 추후 인증 로직 구현시 사용 userId
+                3L,
+                5.0,
+                LocalDateTime.now(),
+                "커피맛집"
+        );
+
+        Review stored = reviewRepository.save(review);
+        Review stored2 = reviewRepository.save(review2);
+
+        assertThat(stored.getId()).isNotEqualTo(stored2.getId());
+
+
+    }
+
+
+}

--- a/src/test/java/com/example/studyspot/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/example/studyspot/review/service/ReviewServiceImplTest.java
@@ -1,0 +1,33 @@
+package com.example.studyspot.review.service;
+
+import com.example.studyspot.review.dto.CreateReviewCommand;
+import com.example.studyspot.review.dto.ReviewResponse;
+import com.example.studyspot.review.repository.MemoryReviewRepository;
+import com.example.studyspot.review.repository.ReviewRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReviewServiceImplTest {
+
+    ReviewRepository reviewRepository = new MemoryReviewRepository();
+    ReviewService reviewService = new ReviewServiceImpl(reviewRepository);
+
+    @Test
+    @DisplayName("dto를 사용하여 리뷰 생성 검증")
+    void 리뷰_생성_검증(){
+        CreateReviewCommand createReviewCommand = new CreateReviewCommand(1L,4.5,"강아지랑 오기 좋아요");
+        ReviewResponse reviewResponse = reviewService.create(createReviewCommand);
+        System.out.println("요청 결과 :" + reviewResponse.id());
+    }
+
+    //추후 작성
+    @Test
+    @DisplayName("리뷰 생성시, 서비스 계층에서 리뷰를 남기려는 카페의 아이디가 유효한 아이디인지 확인해야한다.")
+    void 서비스계층의_유효성_검사_확인(){
+
+    }
+
+}


### PR DESCRIPTION
## 🧩 관련 Issue

Closes #4

---

## 🎯 작업 개요

리뷰 생성 API 구현 완료 : 클라이언트가 리뷰를 작성하면 서버는 리뷰를 db에 올려주고, 리뷰의 id 식별자를 되돌려준다.
- 요청 url : `/reviews/{cafeId}`

1. **클라이언트 request**

경로 변수

- cafeId

request body

- starRating
- content

1. **서버 response**
- id (reviewId)

---

## 🔍 상세 내용

- 변경된 코드 주요 요약
    - review domain 에 반영
- 세부 구현 내용
    - controller → service → repository 프로세스에서 dto, vo 를 활용한 유효성 검사 진행
    - DB 부분을 연동하지 않고 hashMap memory 로 구현 - 추후 연동 예정
    - controller, service, repository 각 계층의 테스트 코드 구현
    - Postman을 활용하여 정상작동 여부 확인
     
        
- 공부한 key word (참고한 자료나 문서)
    - 유효성 검사
    - Lombok
    - restful api
    - `@WebMvcTest` 활용법 : Controller 계층만 로드하는 테스트 전용 에너테이션

---

## ✅ 체크리스트

- [ ]  기능이 정상 동작한다
- [ ]  테스트 코드 통과
- [ ]  코드 리뷰 반영 완료
- [ ]  스타일 가이드 준수

---

## 💬 참고 사항

- 관련 문서/링크
    - BE : CRUD/API 명세서
- 디자인/기획 참고 위치
    - figma : 리뷰 작성 페이지
- 기타 전달 사항
    - 없음