### PR TITLE
[BE-21] feat: 타이머 API에 인증 토큰 연동하기

### DIFF
--- a/src/main/java/com/example/studyspot/timer/controller/TimerController.java
+++ b/src/main/java/com/example/studyspot/timer/controller/TimerController.java
@@ -1,5 +1,6 @@
 package com.example.studyspot.timer.controller;
 
+import com.example.studyspot.common.annotation.UserId;
 import com.example.studyspot.common.api.ResponseEntityGenerator;
 import com.example.studyspot.common.api.SuccessBody;
 import com.example.studyspot.timer.dto.*;
@@ -21,25 +22,30 @@ public class TimerController {
 
     @PostMapping
     public ResponseEntity<SuccessBody<CreateTimerResponse>> createTimer(
-            @Valid @RequestBody CreateTimerRequest body
+            @Valid @RequestBody CreateTimerRequest body,
+            @UserId Long userId
     ){
-        CreateTimerResponse created = timerService.createTimer(body);
+        CreateTimerResponse created = timerService.createTimer(body,userId);
         return ResponseEntityGenerator.success(created, HttpStatus.CREATED);
     }
 
     @GetMapping
-    public ResponseEntity<SuccessBody<ReadTimersResponse>> getAllTimers(){
-        List<ReadTimerResponse> allTimers = timerService.getAllTimers();
+    public ResponseEntity<SuccessBody<ReadTimersResponse>> getAllTimers(
+            @UserId Long userId
+    ){
+        List<ReadTimerResponse> allTimers = timerService.getAllTimers(userId);
         return ResponseEntityGenerator.success(new ReadTimersResponse(allTimers),HttpStatus.OK);
     }
 
     @PostMapping("/{timerId}/logs")
     public ResponseEntity<SuccessBody<CreateLogResponse>> saveLog(
             @PathVariable Long timerId,
-            @Valid @RequestBody CreateLogRequest body
+            @Valid @RequestBody CreateLogRequest body,
+            @UserId Long userId
             ){
         CreateLogResponse created = timerService.createLog(
-                new CreateLogCommand(timerId, body.startAt(), body.endAt(), body.focusDuration())
+                new CreateLogCommand(timerId, body.startAt(), body.endAt(), body.focusDuration()),
+                userId
         );
 
         return ResponseEntityGenerator.success(created, HttpStatus.CREATED);
@@ -50,12 +56,11 @@ public class TimerController {
             @RequestParam List<Long> timerId,
             @RequestParam long start,
             @RequestParam long end,
-            @RequestParam(defaultValue = "false") boolean withTotalTime
+            @RequestParam(defaultValue = "false") boolean withTotalTime,
+            @UserId Long userId
     ){
-        ReadLogsOfTimer dailyStudySummary = timerService.getDailyStudySummary(timerId, start, end);
+        ReadLogsOfTimer dailyStudySummary = timerService.getDailyStudySummary(timerId, start, end, userId, withTotalTime);
         return ResponseEntityGenerator.success(dailyStudySummary, HttpStatus.OK);
     }
-
-
 
 }

--- a/src/main/java/com/example/studyspot/timer/dto/ReadLogsOfTimer.java
+++ b/src/main/java/com/example/studyspot/timer/dto/ReadLogsOfTimer.java
@@ -3,6 +3,7 @@ package com.example.studyspot.timer.dto;
 import java.util.List;
 
 public record ReadLogsOfTimer(
-        List<DailyStudySummaryResponse> logsOfTimer
+        List<DailyStudySummaryResponse> logsOfTimer,
+        TotalStudyOfDayResponse totalTime
 ){
 }

--- a/src/main/java/com/example/studyspot/timer/dto/TotalStudyOfDayResponse.java
+++ b/src/main/java/com/example/studyspot/timer/dto/TotalStudyOfDayResponse.java
@@ -1,0 +1,9 @@
+package com.example.studyspot.timer.dto;
+
+import java.util.List;
+
+public record TotalStudyOfDayResponse (
+        long totalDuration,
+        List<DailyStudyOfDayResponse> durationOfDate
+){
+}

--- a/src/main/java/com/example/studyspot/timer/exception/TimerErrorType.java
+++ b/src/main/java/com/example/studyspot/timer/exception/TimerErrorType.java
@@ -4,7 +4,8 @@ import com.example.studyspot.common.exception.ErrorType;
 import org.springframework.http.HttpStatus;
 
 public enum TimerErrorType implements ErrorType {
-    TIMER_NOT_FOUND("REVIEW-0001",HttpStatus.NOT_FOUND, "해당 타이머가 없습니다.");
+    TIMER_NOT_FOUND("REVIEW-0001",HttpStatus.NOT_FOUND, "해당 타이머가 없습니다."),
+    UNAUTHORIZED_TIMER_ACCESS("TIMER-0002", HttpStatus.FORBIDDEN, "해당 타이머에 접근할 권한이 없습니다.");
 
     private final String errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/studyspot/timer/repository/TimerRepository.java
+++ b/src/main/java/com/example/studyspot/timer/repository/TimerRepository.java
@@ -3,7 +3,9 @@ package com.example.studyspot.timer.repository;
 import com.example.studyspot.timer.domain.model.Timer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TimerRepository extends JpaRepository<Timer, Long> {
+import java.util.List;
 
+public interface TimerRepository extends JpaRepository<Timer, Long> {
+    List<Timer> findByUuserId(Long uuserId);
 
 }

--- a/src/main/java/com/example/studyspot/timer/service/TimerService.java
+++ b/src/main/java/com/example/studyspot/timer/service/TimerService.java
@@ -1,5 +1,6 @@
 package com.example.studyspot.timer.service;
 
+import com.example.studyspot.common.annotation.UserId;
 import com.example.studyspot.timer.dto.*;
 
 import java.time.LocalDate;
@@ -7,15 +8,15 @@ import java.util.List;
 
 public interface TimerService {
     //타이머 등록
-    CreateTimerResponse createTimer(CreateTimerRequest createTimerRequest);
+    CreateTimerResponse createTimer(CreateTimerRequest createTimerRequest, Long userId);
     
     //모든 타이머 조회
-    List<ReadTimerResponse> getAllTimers();
+    List<ReadTimerResponse> getAllTimers(Long userId);
 
     //원하는 날짜 사이의 데일리 공부시간 조회
-    ReadLogsOfTimer getDailyStudySummary(List<Long> timerId, long start, long end);
+    ReadLogsOfTimer getDailyStudySummary(List<Long> timerId, long start, long end, Long userId,boolean withTotalTime);
 
     //로그 저장
-    CreateLogResponse createLog(CreateLogCommand createLogCommand);
+    CreateLogResponse createLog(CreateLogCommand createLogCommand, Long userId);
     
 }

--- a/src/main/java/com/example/studyspot/timer/service/TimerServiceImpl.java
+++ b/src/main/java/com/example/studyspot/timer/service/TimerServiceImpl.java
@@ -30,10 +30,10 @@ public class TimerServiceImpl implements TimerService{
 
     @Override
     @Transactional
-    public CreateTimerResponse createTimer(CreateTimerRequest createTimerRequest) {
+    public CreateTimerResponse createTimer(CreateTimerRequest createTimerRequest, Long userId) {
         Timer timer = Timer.from(
                 null,
-                null,
+                userId,
                 createTimerRequest
         );
 
@@ -44,8 +44,9 @@ public class TimerServiceImpl implements TimerService{
 
     @Override
     @Transactional
-    public List<ReadTimerResponse> getAllTimers(){
-        List<Timer> timers = timerRepository.findAll();
+    public List<ReadTimerResponse> getAllTimers(Long userId){
+        List<Timer> timers = timerRepository.findByUuserId(userId);
+
         List<ReadTimerResponse> found = timers.stream()
                 .map(ReadTimerResponse::from)
                 .toList();
@@ -54,19 +55,70 @@ public class TimerServiceImpl implements TimerService{
 
     @Override
     @Transactional
-    public ReadLogsOfTimer getDailyStudySummary(List<Long> timerIds, long start, long end) {
+    public ReadLogsOfTimer getDailyStudySummary(List<Long> timerIds, long start, long end, Long userId,boolean withTotalTime) {
         //long->timestamp
         Timestamp startTS = Timestamp.from(Instant.ofEpochMilli(start));
         Timestamp endTS = Timestamp.from(Instant.ofEpochMilli(end));
 
         List<Timer> timers = timerRepository.findAllById(timerIds);
 
+        //userId가 맞지 않는 타이머가 하나라도 있는지 검사
+        timers.stream()
+                .filter(timer -> !timer.getUuserId().equals(userId))
+                .findAny()
+                .ifPresent(t->{
+                    throw new StudySpotException(TimerErrorType.UNAUTHORIZED_TIMER_ACCESS);
+                });
+
         List<DailyStudySummaryResponse> summaries = timers.stream()
                 .map(timer -> buildSummaryForTimer(timer, startTS, endTS))
                 .toList();
 
+        if (withTotalTime==true){
+            return new ReadLogsOfTimer(summaries, getTotalTimeOfDailyStudy(summaries));
+        }
 
-        return new ReadLogsOfTimer(summaries);
+        return new ReadLogsOfTimer(summaries, null);
+    }
+
+    private TotalStudyOfDayResponse getTotalTimeOfDailyStudy(List<DailyStudySummaryResponse> summaries){
+        List<DailyStudyOfDayResponse> allDays = summaries.stream()
+                .flatMap(summary -> summary.durationOfDate().stream())
+                .toList();
+
+        Map<Long, Long> totalByDate = allDays.stream()
+                .collect(groupingBy(
+                        DailyStudyOfDayResponse::date,
+                        summingLong(DailyStudyOfDayResponse::dailyTotalDuration)
+                ));
+
+        List<DailyStudyOfDayResponse> totalDurationOfDate = totalByDate.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey()) // date(long) 기준 정렬
+                .map(entry -> {
+                    long dateLong = entry.getKey();
+                    long dailyTotal = entry.getValue();
+
+                    LocalDate localDate = parseLongDate(dateLong);
+                    char dayChar = convertDayOfWeek(localDate.getDayOfWeek());
+
+                    return new DailyStudyOfDayResponse(
+                            dateLong,
+                            dayChar,
+                            dailyTotal
+                    );
+                })
+                .toList();
+
+        long totalDuration = totalDurationOfDate.stream()
+                .mapToLong(DailyStudyOfDayResponse::dailyTotalDuration)
+                .sum();
+
+        TotalStudyOfDayResponse totalTime = new TotalStudyOfDayResponse(
+                totalDuration,
+                totalDurationOfDate
+        );
+        return totalTime;
+
     }
 
     private DailyStudySummaryResponse buildSummaryForTimer(Timer timer,
@@ -119,6 +171,13 @@ public class TimerServiceImpl implements TimerService{
                 + date.getDayOfMonth();
     }
 
+    private LocalDate parseLongDate(long yyyymmdd) {
+        int year  = (int) (yyyymmdd / 10000);
+        int month = (int) ((yyyymmdd / 100) % 100);
+        int day   = (int) (yyyymmdd % 100);
+        return LocalDate.of(year, month, day);
+    }
+
     private char convertDayOfWeek(DayOfWeek day) {
         return switch (day) {
             case MONDAY    -> '월';
@@ -135,11 +194,17 @@ public class TimerServiceImpl implements TimerService{
 
     @Override
     @Transactional
-    public CreateLogResponse createLog(CreateLogCommand createLogCommand){
+    public CreateLogResponse createLog(CreateLogCommand createLogCommand, Long userId){
 
         // 타이머 조회
         Timer timer = timerRepository.findById(createLogCommand.timerId())
                 .orElseThrow(()-> new StudySpotException(TimerErrorType.TIMER_NOT_FOUND));
+
+
+        // 유저 인증
+        if (!timer.getUuserId().equals(userId)){
+            throw new StudySpotException(TimerErrorType.UNAUTHORIZED_TIMER_ACCESS);
+        }
 
         // 로그 생성
         Log log = Log.from(


### PR DESCRIPTION
## 🧩 관련 Issue
Closes #51 

---

## 🎯 작업 개요
- 기존 타이머 API에 인증 토큰 연동

---

## 🔍 상세 내용
- feat : 만들어둔 타이머 API에 인증 토큰 연동 후 잘 수행되는지 확인하기
- refactor : 로그 조회 부분에서 출력시 `url 부분에 withTotalTime = true` 쿼리 스트링을 작성하면, 각 날짜별 총 공부량도 전달해주기.
- 아쉬운 점 : 데이터를 처리시, 불필요하게 길게 코드를 작성한 것 같다. 추후 리펙토링해보자.
---

## ✅ 체크리스트
- [ ] 기능이 정상 동작한다
- [ ] 테스트 코드 통과
- [ ] 코드 리뷰 반영 완료
- [ ] 스타일 가이드 준수

---

## 💬 참고 사항
- 관련 문서/링크
- 디자인/기획 참고 위치
- 기타 전달 사항
